### PR TITLE
Update protobuf compilation for compatibility with aarch64 (m1)

### DIFF
--- a/libpretixsync/build-postgres.gradle
+++ b/libpretixsync/build-postgres.gradle
@@ -76,7 +76,7 @@ jacocoTestReport {
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.0.0'
+        artifact = 'com.google.protobuf:protoc:3.21.1'
     }
     plugins {
         javalite {
@@ -86,10 +86,9 @@ protobuf {
     generateProtoTasks {
         all().each { task ->
             task.builtins {
-                remove java
-            }
-            task.plugins {
-                javalite {}
+                java {
+                    option "lite"
+                }
             }
         }
     }
@@ -113,7 +112,7 @@ dependencies {
 
     implementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
     implementation 'net.i2p.crypto:eddsa:0.3.0'
-    implementation 'com.google.protobuf:protobuf-lite:3.0.1'
+    implementation 'com.google.protobuf:protobuf-javalite:3.21.1'
 
     kapt 'io.requery:requery-processor:1.6.0'
     annotationProcessor 'javax.annotation:jsr250-api:1.0'

--- a/libpretixsync/build.gradle
+++ b/libpretixsync/build.gradle
@@ -71,20 +71,14 @@ jacocoTestReport {
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.0.0'
-    }
-    plugins {
-        javalite {
-            artifact = 'com.google.protobuf:protoc-gen-javalite:3.0.0'
-        }
+        artifact = 'com.google.protobuf:protoc:3.21.1'
     }
     generateProtoTasks {
         all().each { task ->
             task.builtins {
-                remove java
-            }
-            task.plugins {
-                javalite {}
+                java {
+                    option "lite"
+                }
             }
         }
     }
@@ -108,7 +102,7 @@ dependencies {
 
     implementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
     implementation 'net.i2p.crypto:eddsa:0.3.0'
-    implementation 'com.google.protobuf:protobuf-lite:3.0.1'
+    implementation 'com.google.protobuf:protobuf-javalite:3.21.1'
 
     kapt 'io.requery:requery-processor:1.6.0'
     annotationProcessor 'javax.annotation:jsr250-api:1.0'


### PR DESCRIPTION
Using the current protobuf compiler and moving to the new way of specifying that the lite-variant is enough for us.

Fixes #12.
