### PR TITLE
Allow fallback from online to offline scan

### DIFF
--- a/libpretixsync/src/main/java/eu/pretix/libpretixsync/api/TimeoutApiException.java
+++ b/libpretixsync/src/main/java/eu/pretix/libpretixsync/api/TimeoutApiException.java
@@ -1,0 +1,13 @@
+package eu.pretix.libpretixsync.api;
+
+import org.json.JSONObject;
+
+public class TimeoutApiException extends ApiException {
+    public TimeoutApiException(String msg) {
+        super(msg);
+    }
+
+    public TimeoutApiException(String msg, Exception e) {
+        super(msg, e);
+    }
+}

--- a/libpretixsync/src/main/java/eu/pretix/libpretixsync/check/ProxyCheckProvider.kt
+++ b/libpretixsync/src/main/java/eu/pretix/libpretixsync/check/ProxyCheckProvider.kt
@@ -102,7 +102,8 @@ class ProxyCheckProvider(private val config: ConfigStore, httpClientFactory: Htt
         answers: List<Answer>?,
         ignore_unpaid: Boolean,
         with_badge_data: Boolean,
-        type: TicketCheckProvider.CheckInType
+        type: TicketCheckProvider.CheckInType,
+        nonce: String?
     ): TicketCheckProvider.CheckResult {
         val data: MutableMap<String, Any> = HashMap()
         data["events_and_checkin_lists"] = eventsAndCheckinLists
@@ -112,6 +113,9 @@ class ProxyCheckProvider(private val config: ConfigStore, httpClientFactory: Htt
         data["with_badge_data"] = with_badge_data
         data["source_type"] = source_type
         data["type"] = type
+        if (nonce != null) {
+            data["nonce"] = nonce
+        }
         return try {
             val request = Request.Builder()
                     .url(config.apiUrl + "/proxyapi/v1/rpc/check/")  // todo: does not yet exist

--- a/libpretixsync/src/main/java/eu/pretix/libpretixsync/check/TicketCheckProvider.kt
+++ b/libpretixsync/src/main/java/eu/pretix/libpretixsync/check/TicketCheckProvider.kt
@@ -51,14 +51,17 @@ interface TicketCheckProvider {
         var requiredAnswers: List<RequiredAnswer>? = null
         var position: JSONObject? = null
         var eventSlug: String? = null
+        var offline: Boolean = false
 
-        constructor(type: Type?, message: String?) {
+        constructor(type: Type?, message: String?, offline: Boolean = false) {
             this.type = type
             this.message = message
+            this.offline = offline
         }
 
-        constructor(type: Type?) {
+        constructor(type: Type?, offline: Boolean = false) {
             this.type = type
+            this.offline = offline
         }
 
         constructor() {  // required for de-serialization
@@ -126,7 +129,7 @@ interface TicketCheckProvider {
     class StatusResult(var eventName: String?, var totalTickets: Int, var alreadyScanned: Int, var currentlyInside: Int?, var items: List<StatusResultItem>?) {
     }
 
-    fun check(eventsAndCheckinLists: Map<String, Long>, ticketid: String, source_type: String, answers: List<Answer>?, ignore_unpaid: Boolean, with_badge_data: Boolean, type: CheckInType): CheckResult
+    fun check(eventsAndCheckinLists: Map<String, Long>, ticketid: String, source_type: String, answers: List<Answer>?, ignore_unpaid: Boolean, with_badge_data: Boolean, type: CheckInType, nonce: String? = null): CheckResult
     fun check(eventsAndCheckinLists: Map<String, Long>, ticketid: String): CheckResult
     @Throws(CheckException::class)
     fun search(eventsAndCheckinLists: Map<String, Long>, query: String, page: Int): List<SearchResult>

--- a/libpretixsync/src/main/java/eu/pretix/libpretixsync/sync/SyncManager.java
+++ b/libpretixsync/src/main/java/eu/pretix/libpretixsync/sync/SyncManager.java
@@ -722,9 +722,9 @@ public class SyncManager {
                 }
                 if (qci.getDatetime_string() == null || qci.getDatetime_string().equals("")) {
                     // Backwards compatibility
-                    ar = api.redeem(qci.getEvent_slug(), qci.getSecret(), qci.getDatetime(), true, qci.getNonce(), answers, qci.checkinListId, false, false, qci.getType(), st);
+                    ar = api.redeem(qci.getEvent_slug(), qci.getSecret(), qci.getDatetime(), true, qci.getNonce(), answers, qci.checkinListId, false, false, qci.getType(), st, null);
                 } else {
-                    ar = api.redeem(qci.getEvent_slug(), qci.getSecret(), qci.getDatetime_string(), true, qci.getNonce(), answers, qci.checkinListId, false, false, qci.getType(), st);
+                    ar = api.redeem(qci.getEvent_slug(), qci.getSecret(), qci.getDatetime_string(), true, qci.getNonce(), answers, qci.checkinListId, false, false, qci.getType(), st, null);
                 }
                 if (connectivityFeedback != null) {
                     connectivityFeedback.recordSuccess(System.currentTimeMillis() - startedAt);

--- a/libpretixsync/src/test/java/eu/pretix/libpretixsync/test/FakePretixApi.kt
+++ b/libpretixsync/src/test/java/eu/pretix/libpretixsync/test/FakePretixApi.kt
@@ -30,7 +30,18 @@ class FakePretixApi : PretixApi("http://1.1.1.1/", "a", "demo", 1, DefaultHttpCl
     var lastRequestUrl: String? = null
     var lastRequestBody: JSONObject? = null
 
-    override fun redeem(lists: List<Long>, secret: String, datetime: String?, force: Boolean, nonce: String?, answers: List<Answer>?, ignore_unpaid: Boolean, pdf_data: Boolean, type: String?): ApiResponse {
+    override fun redeem(
+        lists: List<Long>,
+        secret: String,
+        datetime: String?,
+        force: Boolean,
+        nonce: String?,
+        answers: List<Answer>?,
+        ignore_unpaid: Boolean,
+        pdf_data: Boolean,
+        type: String?,
+        callTimeout: Long?
+    ): ApiResponse {
         redeemRequestSecret = secret
         redeemRequestDatetime = datetime
         redeemRequestForce = force
@@ -42,7 +53,20 @@ class FakePretixApi : PretixApi("http://1.1.1.1/", "a", "demo", 1, DefaultHttpCl
         return redeemResponses.removeAt(0)()
     }
 
-    override fun redeem(eventSlug: String, secret: String, datetime: String?, force: Boolean, nonce: String?, answers: List<Answer>?, listId: Long, ignore_unpaid: Boolean, pdf_data: Boolean, type: String?, source_type: String?): ApiResponse {
+    override fun redeem(
+        eventSlug: String,
+        secret: String,
+        datetime: String?,
+        force: Boolean,
+        nonce: String?,
+        answers: List<Answer>?,
+        listId: Long,
+        ignore_unpaid: Boolean,
+        pdf_data: Boolean,
+        type: String?,
+        source_type: String?,
+        callTimeout: Long?
+    ): ApiResponse {
         redeemRequestSecret = secret
         redeemRequestDatetime = datetime
         redeemRequestForce = force
@@ -77,7 +101,12 @@ class FakePretixApi : PretixApi("http://1.1.1.1/", "a", "demo", 1, DefaultHttpCl
         return deleteResponses.removeAt(0)()
     }
 
-    override fun postResource(full_url: String, data: String, idempotency_key: String?): ApiResponse {
+    override fun postResource(
+        full_url: String,
+        data: String,
+        idempotency_key: String?,
+        callTimeout: Long?
+    ): ApiResponse {
         lastRequestUrl = full_url
         try {
             lastRequestBody = JSONObject(data)


### PR DESCRIPTION
A large customer wished for better timeout handling of scans if the network goes down. They already use our "automatically switch to offline mode after multiple slow scans" feature, but they don't want to wait the full 30s timeout for multiple scans before they switch to offline.

This PR therefore introduces a fallback option for scans. In other words, if the automatical decision between online and offline mode is enabled, the app can now also change its mind *after* the scan started, i.e. we first try if we can process it online and after a short timeout, we switch to a offline scan without actually requiring another scan.

Now, the following scenarios are relevant:

1) Our original scan attempt has never reached the server or has never been processed there. Therefore, our offline scan will be the only scan recorded. This is acceptable, since it's not worse than if the scanner would have auto-switched to offline mode a minute ago.

2) Our original scan attempt has been processed on the server but we never received the response. The outcome depends on the processing result:

   a) The scan was successful both on the server as well as with our fallback method. Everything is fine. Since both scans carry the same "nonce", only one scan will be in the database since the server ignores our upload of the offline scan later.

    b) The scan failed on the server as well as with our fallback method: Everything is fine. Since both scans carry the same "nonce", only one scan will be in the database since the server ignores our upload of the offline scan later.

    c) The scan failed on the server, but our fallback method recorded a successful scan: This is not great, because someone got in who shouldn't have, but it's no worse than if the scanner would have auto-switched to offline mode a minute ago, so it's acceptable by any user who configured our app like this. The database will later show both a failed and a successful scan (since nonces of failed scans do not block further scans), but that's also the most sensible description of what happened to a user who looks at the process in the backend, so we consider it acceptable. It's also no different to a user manually quickly retrying the scan after a failure.

    d) The scan succeeded on the server, but failed with our fallback method. This is the worst situation since a valid scan is recorded and the ticket is now marked as used, even though the ticket holder did not get in. This risk always existed as it can happen in any situation where the request reached the server but the response did not reach the scanner, but it becomes a more likely situation with a lower timeout. Maybe that's just a risk that needs to be accepted by anyone using this feature? I'm not *too* concerned since usually the offline mode is *usually* more likely to return a successful scan than the online mode (e.g. with signature-based scanning). We **could** implement this differently through a server-side mechanism that deletes the successful scan later, when the app uploads a failed scan with the same nonce. I'm not sure whether we should, though, because ``Checkin`` records on the server are currently kinda immutable and hence audit-proof. Introducing a mechanism that removes successful checkins after the fact sounds like a big risk as well.

Dependent PR: https://github.com/pretix/pretixscan-android/pull/71

Required PR: https://github.com/pretix/pretix/pull/3516