### PR TITLE
Fix crash on very large orders

### DIFF
--- a/libpretixsync/src/main/java/eu/pretix/libpretixsync/sync/OrderSyncAdapter.java
+++ b/libpretixsync/src/main/java/eu/pretix/libpretixsync/sync/OrderSyncAdapter.java
@@ -291,7 +291,9 @@ public class OrderSyncAdapter extends BaseDownloadSyncAdapter<Order, String> {
         obj.setEmail(jsonobj.optString("email"));
         obj.setCheckin_attention(jsonobj.optBoolean("checkin_attention"));
         obj.setValid_if_pending(jsonobj.optBoolean("valid_if_pending", false));
-        obj.setJson_data(jsonobj.toString());
+        JSONObject json_data = new JSONObject(jsonobj.toString());
+        json_data.remove("positions");
+        obj.setJson_data(json_data.toString());
         obj.setDeleteAfterTimestamp(0L);
 
         if (obj.getId() == null) {


### PR DESCRIPTION
If an order with ~300 positions exist, even just fetching it from the database will crash our Android apps with something like:
```
2023-11-23 14:44:10.584  5926-6299  SQLiteQuery             eu.pretix.pretixpos.debug            E  exception: Row too big to fit into CursorWindow requiredPos=0, totalRows=1; query: select id, checkin_attention, code, deleteAfterTimestamp, email, event_slug, json_data, status, valid_if_pending from orders where code = ?
```

This PR stops storing the entire JSON representation of positions within the order itself, as we already have it in the individual row of the positions, therefore fixing the issue. Unfortunately, this introduces a likely performance regression in the cleanup of old subevents.

It will also require a change to some features in pretixPOS, for which I'll create a separate PR.