### PR TITLE
Add source_type to OnlineRedemption when using lists

### DIFF
--- a/libpretixsync/src/main/java/eu/pretix/libpretixsync/api/PretixApi.kt
+++ b/libpretixsync/src/main/java/eu/pretix/libpretixsync/api/PretixApi.kt
@@ -90,16 +90,16 @@ open class PretixApi(url: String, key: String, orgaSlug: String, version: Int, h
     }
 
     @Throws(ApiException::class, JSONException::class)
-    fun redeem(lists: List<Long>, secret: String, datetime: Date?, force: Boolean, nonce: String?, answers: List<Answer>?, ignore_unpaid: Boolean, pdf_data: Boolean, type: String?, callTimeout: Long? = null, questions_supported: Boolean = true): ApiResponse {
+    fun redeem(lists: List<Long>, secret: String, datetime: Date?, force: Boolean, nonce: String?, answers: List<Answer>?, ignore_unpaid: Boolean, pdf_data: Boolean, type: String?, source_type: String?, callTimeout: Long? = null, questions_supported: Boolean = true): ApiResponse {
         var dt: String? = null
         if (datetime != null) {
             dt = QueuedCheckIn.formatDatetime(datetime)
         }
-        return redeem(lists, secret, dt, force, nonce, answers, ignore_unpaid, pdf_data, type, callTimeout, questions_supported)
+        return redeem(lists, secret, dt, force, nonce, answers, ignore_unpaid, pdf_data, type, source_type, callTimeout, questions_supported)
     }
 
     @Throws(ApiException::class, JSONException::class)
-    open fun redeem(lists: List<Long>, secret: String, datetime: String?, force: Boolean, nonce: String?, answers: List<Answer>?, ignore_unpaid: Boolean, pdf_data: Boolean, type: String?, callTimeout: Long? = null, questions_supported: Boolean = true): ApiResponse {
+    open fun redeem(lists: List<Long>, secret: String, datetime: String?, force: Boolean, nonce: String?, answers: List<Answer>?, ignore_unpaid: Boolean, pdf_data: Boolean, type: String?, source_type: String?, callTimeout: Long? = null, questions_supported: Boolean = true): ApiResponse {
         val body = JSONObject()
         if (datetime != null) {
             body.put("datetime", datetime)
@@ -108,6 +108,7 @@ open class PretixApi(url: String, key: String, orgaSlug: String, version: Int, h
         body.put("ignore_unpaid", ignore_unpaid)
         body.put("nonce", nonce)
         body.put("type", type)
+        body.put("source_type", source_type ?: "barcode")
         val answerbody = JSONObject()
         if (answers != null) {
             for (a in answers) {

--- a/libpretixsync/src/main/java/eu/pretix/libpretixsync/check/OnlineCheckProvider.kt
+++ b/libpretixsync/src/main/java/eu/pretix/libpretixsync/check/OnlineCheckProvider.kt
@@ -69,6 +69,7 @@ class OnlineCheckProvider(
                     ignore_unpaid,
                     with_badge_data,
                     type.toString().lowercase(Locale.getDefault()),
+                    source_type,
                     callTimeout = if (fallback != null) fallbackTimeout.toLong() else null,
                     questions_supported = allowQuestions,
                 )

--- a/libpretixsync/src/testFixtures/java/eu/pretix/pretixscan/scanproxy/tests/test/FakePretixApi.kt
+++ b/libpretixsync/src/testFixtures/java/eu/pretix/pretixscan/scanproxy/tests/test/FakePretixApi.kt
@@ -40,6 +40,7 @@ class FakePretixApi : PretixApi("http://1.1.1.1/", "a", "demo", 1, DefaultHttpCl
         ignore_unpaid: Boolean,
         pdf_data: Boolean,
         type: String?,
+        source_type: String?,
         callTimeout: Long?,
         questions_supported: Boolean
     ): ApiResponse {


### PR DESCRIPTION
Right now, the redeem()-functions ignore the source_type when used with a list of checkinlists. This should fix this.