### PR TITLE
AsyncCheckProvider: Fix item matching for addon match (Z#23241414)

### DIFF
--- a/libpretixsync/src/main/java/eu/pretix/libpretixsync/check/AsyncCheckProvider.kt
+++ b/libpretixsync/src/main/java/eu/pretix/libpretixsync/check/AsyncCheckProvider.kt
@@ -697,10 +697,10 @@ class AsyncCheckProvider(private val config: ConfigStore, private val db: SyncDa
             }
 
             // server side: 3a.
-            var resultingPositions = mutableSetOf(position)
+            var resultingPositions = mutableSetOf<OrderPositionModel>()
             if (list.addonMatch) {
                 // Add-on matching, as per spec, but only if we have data, it's impossible in data-less mode
-                val candidates = mutableListOf<OrderPositionModel>()
+                val candidates = mutableListOf<OrderPositionModel>(position)
 
                 val orderPositions = db.orderPositionQueries.selectForOrder(order.id).executeAsList()
                     .map { it.toModel() }
@@ -734,6 +734,8 @@ class AsyncCheckProvider(private val config: ConfigStore, private val db: SyncDa
                 } else {
                     resultingPositions.add(filteredCandidates[0])
                 }
+            } else {
+                resultingPositions.add(position)
             }
 
             results.addAll(resultingPositions)


### PR DESCRIPTION
The old logic didn't really match the serverside algorithm in that the parent product was not checked against the item filter, which doesn't make much sense.